### PR TITLE
fix: fixed card swipe to show next book img

### DIFF
--- a/screens/BookMatchingScreen.tsx
+++ b/screens/BookMatchingScreen.tsx
@@ -177,7 +177,7 @@ useEffect(() => {
         {nextProfile && ( 
       <View style={styles.nextCardContainer}>
         <Animated.View style={[styles.animatedCard,nextCardStyle]}>
-           <BookCard bookData={nextProfile} index={currentIndex}/>
+           <BookCard bookData={nextProfile} index={nextIndex}/>
         </Animated.View>
         </View>
         )}


### PR DESCRIPTION
it still re-render, but is showing the next card img when swipe.